### PR TITLE
fix: update isHttpError return type

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -102,7 +102,7 @@ export function createError(
   return new HttpError(status, message, properties)
 }
 
-export function isHttpError(error: any): boolean {
+export function isHttpError(error: any): error is HttpError {
   if (typeof error !== 'object' || !error) {
     return false
   } else if (error instanceof HttpError) {


### PR DESCRIPTION
Hi there! 👋🏼 Please I'm using this package in one my projects and it's really nice. 
I had an issue tho' where I'm doing this...
```ts
export function handleError<T extends unknown>(exception: T) {
  //  getting this error: Property 'expose' does not exist on type 'T'
  //  since the return type of the isHttpError function is boolean 
  //  not the more stricter HttpError which has the expose property
  if (isHttpError(exception) && exception.expose) { 

  }
```
and I'd like to contribute if you're open to it. 

I replaced the return type of the isHttpError type guard with the type predicate `error is HttpError` instead of the looser `boolean` type. 
This allows the error have the types of the HttpError class.